### PR TITLE
Sets the project up to use celery

### DIFF
--- a/mariner/async.py
+++ b/mariner/async.py
@@ -1,0 +1,19 @@
+import os
+import pecan
+
+from celery import Celery
+from celery.signals import worker_init
+
+
+@worker_init.connect
+def bootstrap_pecan(signal, sender):
+    try:
+        config_path = os.environ['PECAN_CONFIG']
+    except KeyError:
+        here = os.path.abspath(os.path.dirname(__file__))
+        config_path = os.path.abspath(os.path.join(here, '../config/config.py'))
+
+    pecan.configuration.set_config(config_path, overwrite=True)
+
+
+app = Celery('mariner.async', broker='amqp://guest@localhost//', include=['mariner.tasks'])

--- a/mariner/tasks.py
+++ b/mariner/tasks.py
@@ -1,0 +1,6 @@
+from celery import shared_task
+
+
+@shared_task
+def celery_task():
+    pass


### PR DESCRIPTION
Use mariner.async as the file you point the celery command at
and tasks can be written in mariner.tasks.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>