### PR TITLE
Improve schema error reporting

### DIFF
--- a/mariner/controllers/errors.py
+++ b/mariner/controllers/errors.py
@@ -11,9 +11,14 @@ class ErrorController(object):
     @expose('json')
     def schema(self, **kw):
         response.status = 400
-        error_message = request.validation_error.reason or str(request.validation_error)
-        schema_logger.error(error_message)
-        return dict(message=error_message)
+        schema_logger.error(request.validation_error)
+        path = request.validation_error._format_path()
+        message = '%s%sfailed validation, %s' % (
+            path,
+            '' if path.endswith(' ') else ' ',
+            request.validation_error.reason
+        )
+        return dict(message=message)
 
     @expose('json')
     def invalid(self, **kw):

--- a/mariner/controllers/errors.py
+++ b/mariner/controllers/errors.py
@@ -13,7 +13,7 @@ class ErrorController(object):
         response.status = 400
         error_message = request.validation_error.reason or str(request.validation_error)
         schema_logger.error(error_message)
-        return dict(message=str(request.reason))
+        return dict(message=error_message)
 
     @expose('json')
     def invalid(self, **kw):

--- a/mariner/controllers/errors.py
+++ b/mariner/controllers/errors.py
@@ -1,4 +1,9 @@
+import logging
 from pecan import expose, response, request
+
+
+logger = logging.getLogger(__name__)
+schema_logger = logging.getLogger("%s.schema" % __name__)
 
 
 class ErrorController(object):
@@ -6,7 +11,9 @@ class ErrorController(object):
     @expose('json')
     def schema(self, **kw):
         response.status = 400
-        return dict(message=str(request.validation_error))
+        error_message = request.validation_error.reason or str(request.validation_error)
+        schema_logger.error(error_message)
+        return dict(message=str(request.reason))
 
     @expose('json')
     def invalid(self, **kw):

--- a/mariner/schemas.py
+++ b/mariner/schemas.py
@@ -3,7 +3,8 @@ from notario.decorators import optional
 
 
 def list_of_hosts(value):
-    assert isinstance(value, list), "Please provide a list of hosts in the format: ['host1', 'host2']"
+    assert isinstance(value, list), "requires format: ['host1', 'host2']"
+
 
 install_schema = (
     (optional("adjust-repos"), types.boolean),

--- a/mariner/tests/controllers/test_errors.py
+++ b/mariner/tests/controllers/test_errors.py
@@ -1,0 +1,27 @@
+
+
+class TestSchemaErrors(object):
+
+    def test_install_empty_object(self, session):
+        result = session.app.post_json("/api/mon/install/", params=dict(),
+                                       expect_errors=True)
+        message = result.json['message']
+        assert message.endswith('an empty dictionary object was provided')
+
+    def test_host_is_invalid(self, session):
+        params = {'hosts': ''}
+        result = session.app.post_json("/api/mon/install/", params=params,
+                                       expect_errors=True)
+        message = result.json['message']
+        assert "hosts" in message
+        assert message.endswith(
+                "failed validation, requires format: ['host1', 'host2']"
+        )
+
+    def test_release_is_wrong_type(self, session):
+        params = {'hosts': ['node1'], 'release': False}
+        result = session.app.post_json("/api/mon/install/", params=params,
+                                       expect_errors=True)
+        message = result.json['message']
+        assert message.endswith('not of type string')
+        assert 'release' in message


### PR DESCRIPTION
The "path" portion on schema errors is important. We can't simply use the 'reason' because it doesn't provide information like what key was at fault.

For example a JSON body that looks like:

    {"foo": true, "bar": "no"}

And a schema that validates that `"bar"` must be a boolean would fail but the error message that was being used would indicate that "validation failed, not of type boolean". 

This PR solves this and adds some tests. It also creates a new logger so that the full unchanged exception is logged.