### PR TITLE
kickstart script over http

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,36 @@ It follows these concepts:
 
 Endpoints
 =========
-The parent endpoint for any API interaction is ``/api/``.
+The parent endpoint for any API interaction is ``/api/``. The service provides
+a setup script as well that can be used to ensure a remote node can comply with
+certain requirements like: a deployment user, ssh keys, and sudo permissions.
+
+``setup``
+=========
+
+``/setup/``
+-----------
+* ``GET``: Generates a BASH script to be downloaded as ``setup.sh``. This
+  script should be executed with super user privileges on the remote node as it
+  will perform the following actions:
+
+  * create an ``ansible`` user
+  * ensure that the ``ansible`` user can use sudo without a password prompt
+  * remove the ``requiretty`` from ``/etc/sudoers`` if set, so that SSH
+    connections allow non-interactive sessions from using ``sudo``
+  * retrieve the SSH key that will be used for provisioning (see
+    :ref:`provisioning_key`)
+  * append the provisioning key onto ``$HOME/ansible/.ssh/authorized_keys``
+
+.. _provisioning_key:
+
+``/setup/key/``
+---------------
+This endpoint will serve the public SSH key *from the user that is running the
+service* assuming the location of: ``$HOME/.ssh/id_rsa.pub``. If this file does
+not exist the service will proceed to create one *while processing the
+request*.
+
 
 ``api``
 =======

--- a/config/config.py
+++ b/config/config.py
@@ -18,7 +18,7 @@ logging = {
     'root': {'level': 'INFO', 'handlers': ['console']},
     'loggers': {
         'mariner': {'level': 'DEBUG', 'handlers': ['console'], 'propagate': False},
-        'pecan': {'level': 'DEBUG', 'handlers': ['console'], 'propagate': False},
+        'pecan': {'level': 'INFO', 'handlers': ['console'], 'propagate': False},
         'py.warnings': {'handlers': ['console']},
         '__force_dict__': True
     },

--- a/mariner/controllers/root.py
+++ b/mariner/controllers/root.py
@@ -1,5 +1,5 @@
 from pecan import expose
-from mariner.controllers import tasks, mon, osd, rgw, calamari, errors
+from mariner.controllers import tasks, mon, osd, rgw, calamari, errors, setup
 
 
 class ApiController(object):
@@ -25,3 +25,4 @@ class RootController(object):
 
     api = ApiController()
     errors = errors.ErrorController()
+    setup = setup.SetupController()

--- a/mariner/controllers/setup.py
+++ b/mariner/controllers/setup.py
@@ -21,7 +21,7 @@ class SetupController(object):
         """
         # look for the ssh key of the current user
         private_key_path = os.path.expanduser('~/.ssh/id_rsa')
-        public_key_path = os.path.expanduser('~/.ssh/id_rsa')
+        public_key_path = os.path.expanduser('~/.ssh/id_rsa.pub')
 
         # if there isn't one create it
         if not os.path.exists(public_key_path):

--- a/mariner/controllers/setup.py
+++ b/mariner/controllers/setup.py
@@ -1,0 +1,42 @@
+from pecan import expose, request, response
+from webob.static import FileIter
+from mariner.util import make_setup_script
+from mariner import process
+import os
+from StringIO import StringIO
+
+
+class SetupController(object):
+
+    @expose(content_type='application/octet-stream')
+    def index(self):
+        script = make_setup_script(request.url)
+        response.headers['Content-Disposition'] = 'attachment; filename=setup.sh'
+        response.app_iter = FileIter(script)
+
+    @expose(content_type='application/octet-stream')
+    def key(self):
+        """
+        Serves the public SSH key for the user that own the current service
+        """
+        # look for the ssh key of the current user
+        private_key_path = os.path.expanduser('~/.ssh/id_rsa')
+        public_key_path = os.path.expanduser('~/.ssh/id_rsa')
+
+        # if there isn't one create it
+        if not os.path.exists(public_key_path):
+            # create one
+            command = [
+                    'ssh-keygen', '-q', '-t', 'rsa',
+                    '-N', '""',
+                    '-f', private_key_path,
+            ]
+            process.run(command, send_input='y\n')
+
+        # define the file to download
+        response.headers['Content-Disposition'] = 'attachment; filename=id_rsa.pub'
+        with open(public_key_path) as key_contents:
+            key = StringIO()
+            key.write(key_contents.read())
+            key.seek(0)
+        response.app_iter = FileIter(key)

--- a/mariner/process.py
+++ b/mariner/process.py
@@ -27,12 +27,9 @@ def temp_file(identifier, std):
     )
 
 
-def run(arguments, **kwargs):
+def run(arguments, send_input=None, **kwargs):
     """
     A small helper to run a system command using ``subprocess.Popen``.
-    Opinionated becuase it will always want to Safely execute
-    a ``subprocess.Popen`` call making sure that the executable exists and
-    raising a helpful error message if it does not.
 
     This returns the output of the command and the return code of the process
     in a tuple::
@@ -45,5 +42,7 @@ def run(arguments, **kwargs):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         **kwargs)
+    if send_input:
+        process.communicate(input=send_input)
     out, err = process.communicate()
     return out, err, process.returncode

--- a/mariner/tests/config.py
+++ b/mariner/tests/config.py
@@ -15,7 +15,7 @@ logging = {
     'root': {'level': 'INFO', 'handlers': ['console']},
     'loggers': {
         'mariner': {'level': 'DEBUG', 'handlers': ['console'], 'propagate': False},
-        'pecan': {'level': 'DEBUG', 'handlers': ['console'], 'propagate': False},
+        'pecan': {'level': 'INFO', 'handlers': ['console'], 'propagate': False},
         'py.warnings': {'handlers': ['console']},
         '__force_dict__': True
     },

--- a/mariner/tests/controllers/test_mon.py
+++ b/mariner/tests/controllers/test_mon.py
@@ -1,3 +1,5 @@
+from mariner.controllers import mon
+
 
 class TestMonController(object):
 
@@ -21,3 +23,11 @@ class TestMonController(object):
         result = session.app.post_json("/api/mon/install/", params=data,
                                        expect_errors=True)
         assert result.status_int == 400
+
+    def test_install_hosts(self, session, monkeypatch):
+        monkeypatch.setattr(mon.install, 'apply_async', lambda x: None)
+        data = dict(hosts=["node1"])
+        result = session.app.post_json("/api/mon/install/", params=data,
+                                       expect_errors=True)
+        assert result.json['endpoint'] == '/api/mon/install/'
+        assert result.json['identifier'] is not None

--- a/mariner/tests/test_util.py
+++ b/mariner/tests/test_util.py
@@ -40,3 +40,7 @@ class TestGetEndpoint(object):
     def test_one_arg(self):
         result = util.get_endpoint('http://example.org/some/endpoint', 'setup')
         assert result == 'http://example.org/setup/'
+
+    def test_no_trailing_slash(self):
+        result = util.get_endpoint('http://example.org', 'setup')
+        assert result == 'http://example.org/setup/'

--- a/mariner/tests/test_util.py
+++ b/mariner/tests/test_util.py
@@ -29,3 +29,14 @@ class TestGenerateInventoryFile(object):
     def test_tmp_dir(session, tmpdir):
         result = util.generate_inventory_file("mons", "google.com", "uuid", tmp_dir=str(tmpdir))
         assert str(tmpdir) in result
+
+
+class TestGetEndpoint(object):
+
+    def test_no_args(self):
+        result = util.get_endpoint('http://example.org/some/endpoint')
+        assert result == 'http://example.org/'
+
+    def test_one_arg(self):
+        result = util.get_endpoint('http://example.org/some/endpoint', 'setup')
+        assert result == 'http://example.org/setup/'

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -140,6 +140,11 @@ def make_setup_script(url):
     """
     ssh_key_address = get_endpoint(url, 'setup', 'key')
     bash = """#!/bin/bash -x -e
+if [[ $EUID -ne 0 ]]; then
+  echo "You must be a root user or execute this script with sudo" 2>&1
+  exit 1
+fi
+
 echo "--> creating new user with disabled password: ansible"
 adduser --disabled-password --gecos "" ansible
 

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -127,6 +127,8 @@ def get_endpoint(request_url, *args):
     if args:
         for part in args:
             url = os.path.join(url, part)
+    if not url.endswith('/'):
+        return "%s/" % url
     return url
 
 

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -141,9 +141,6 @@ def make_setup_script(url):
 echo "--> creating new user: ansible"
 adduser ansible
 
-echo "--> fetching public ssh key"
-curl -s -L -o ansible.pub
-
 echo "--> adding provisioning key to the ansible authorized_keys"
 curl -s -L -o ansible.pub {ssh_key_address}
 cat ansible.pub >> /home/ansible/.ssh/authorized_keys

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -2,6 +2,8 @@ import os
 import pecan
 import tempfile
 import logging
+from StringIO import StringIO
+
 
 logger = logging.getLogger(__name__)
 
@@ -101,3 +103,65 @@ def get_playbook_path():
         return os.path.join(playbook_path, 'site.yml')
 
     # TODO: error here in a way that a controller can handle it and report back
+
+
+def get_endpoint(request_url, *args):
+    """
+    Given a request URL, attempt to determine the full address to the `/setup/`
+    endpoint so that we can re-use this when crafting the script.
+
+    This service might not be reached at the same address as the configuration
+    states so we try to match the request to ensure a subsequent request that
+    can capture stdout/stderr will be correct.
+
+    The ``request_url`` argument is required, and used to infer the base url
+    this service was accessed from. All args would then be used to append to
+    the main url::
+
+        >>> get_endpoint('http://localhost:8080/some/endpoint', 'api', 'setup')
+        'http://localhost:8080/api/setup/'
+
+    ``request_url``: A string representing the full URL like ``http://api.example.com/api/``.
+    """
+    url = '/'.join(request_url.split('/')[:3])
+    if args:
+        for part in args:
+            url = os.path.join(url, part)
+    return url
+
+
+def make_setup_script(url):
+    """
+    Create a setup script. Done dynamically due to the need of identifying the
+    correct url used to request this service. The scrip will use this URL to
+    properly create the right location for the serving of the public ssh key.
+    """
+    ssh_key_address = get_endpoint(url, 'api', 'setup', 'key')
+    bash = """#!/bin/bash -x -e
+echo "--> creating new user: ansible"
+adduser ansible
+
+echo "--> fetching public ssh key"
+curl -s -L -o ansible.pub
+
+echo "--> adding provisioning key to the ansible authorized_keys"
+curl -s -L -o ansible.pub {ssh_key_address}
+cat ansible.pub >> /home/ansible/.ssh/authorized_keys
+
+echo -e "--> backing up /etc/sudoers to /etc/sudoers.bak"
+cp /etc/sudoers /etc/sudoers.bak
+
+echo "--> ensuring /etc/sudoers will not require a tty"
+sed -i "s/Defaults    requiretty/#Defaults    requiretty/" /etc/sudoers
+
+echo "--> ensuring that ansible user will be able to sudo"
+echo "ansible ALL=(ALL) ALL" | sudo tee /etc/sudoers.d/ansible > /dev/null
+"""
+    script = StringIO()
+    script.write(
+        bash.format(
+            ssh_key_address=ssh_key_address,
+        )
+    )
+    script.seek(0)
+    return script

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -140,12 +140,14 @@ def make_setup_script(url):
     """
     ssh_key_address = get_endpoint(url, 'setup', 'key')
     bash = """#!/bin/bash -x -e
-echo "--> creating new user: ansible"
-adduser ansible
+echo "--> creating new user with disabled password: ansible"
+adduser --disabled-password --gecos "" ansible
 
 echo "--> adding provisioning key to the ansible authorized_keys"
 curl -s -L -o ansible.pub {ssh_key_address}
+mkdir -p /home/ansible/.ssh
 cat ansible.pub >> /home/ansible/.ssh/authorized_keys
+chown -R ansible:ansible /home/ansible/.ssh
 
 echo -e "--> backing up /etc/sudoers to /etc/sudoers.bak"
 cp /etc/sudoers /etc/sudoers.bak
@@ -154,7 +156,7 @@ echo "--> ensuring /etc/sudoers will not require a tty"
 sed -i "s/Defaults    requiretty/#Defaults    requiretty/" /etc/sudoers
 
 echo "--> ensuring that ansible user will be able to sudo"
-echo "ansible ALL=(ALL) ALL" | sudo tee /etc/sudoers.d/ansible > /dev/null
+echo "ansible ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/ansible > /dev/null
 """
     script = StringIO()
     script.write(

--- a/mariner/util.py
+++ b/mariner/util.py
@@ -136,7 +136,7 @@ def make_setup_script(url):
     correct url used to request this service. The scrip will use this URL to
     properly create the right location for the serving of the public ssh key.
     """
-    ssh_key_address = get_endpoint(url, 'api', 'setup', 'key')
+    ssh_key_address = get_endpoint(url, 'setup', 'key')
     bash = """#!/bin/bash -x -e
 echo "--> creating new user: ansible"
 adduser ansible


### PR DESCRIPTION
Serves a generated BASH script to be consumed over HTTP and executed on remote nodes (see doc updates for a full description).

Creates two endpoints for this: ``/setup/`` and ``/setup/key/``, both documented.

Adds tests related to these new utilities and endpoints and a few non-related to this feature